### PR TITLE
Fix Ruby example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Have a `Array.prototype.equals` method, they might look like:
 
 __How are other langugaes handling this?__
 
-__Ruby:__ `array1.to_set == array2.to_set`
+__Ruby:__ `array1 == array2`
 
 __Python:__ `[1,[2,3]] == [1,[2,3]]`
 


### PR DESCRIPTION
`array1.to_set == array1.to_set` first converts both arrays to sets and then checks for the equality of sets, it's not what this proposal aims to add to JS